### PR TITLE
74 x systematics daniel

### DIFF
--- a/RA4Analysis/plotsDaniel/WMass.py
+++ b/RA4Analysis/plotsDaniel/WMass.py
@@ -246,9 +246,9 @@ for srNJet in sorted(signalRegions):
 
 print "Results"
 print
-print '\\begin{table}[ht]\\begin{center}\\resizebox{\\textwidth}{!}{\\begin{tabular}{|c|c|c|rrr|rrr|rrr|rrr|rrr|rrr|}\\hline'
-print ' \\njet & \ST & \HT     &\multicolumn{9}{c|}{$R_{CS}$} &\multicolumn{6}{c|}{yield $\Delta\Phi\geq x$} &\multicolumn{3}{c|}{ratio}\\\%\hline'
-print ' & $[$GeV$]$ &$[$GeV$]$ & \multicolumn{3}{c}{$m_{W}<100$} & \multicolumn{3}{c}{$m_{W}\geq100$} & \multicolumn{3}{c|}{total} & \multicolumn{3}{c}{$m_{W}<100$} & \multicolumn{3}{c|}{$m_{W}\geq100$} & \multicolumn{3}{c|}{$\\frac{m_{W}\geq100}{m_{W}<100}$}\\\ '
+print '\\begin{table}[ht]\\begin{center}\\resizebox{\\textwidth}{!}{\\begin{tabular}{|c|c|c|rrr|rrr|rrr|rrr|rrr|rrr|rrr|rrr|}\\hline'
+print ' \\njet & \ST & \HT     &\multicolumn{9}{c|}{$R_{CS}$} & \multicolumn{6}{c|}{yield $\Delta\Phi< x$} & \multicolumn{6}{c|}{yield $\Delta\Phi\geq x$} & \multicolumn{3}{c|}{ratio}\\\%\hline'
+print ' & $[$GeV$]$ &$[$GeV$]$ & \multicolumn{3}{c}{$m_{W}<100$} & \multicolumn{3}{c}{$m_{W}\geq100$} & \multicolumn{3}{c}{$m_{W}<100$} & \multicolumn{3}{c}{$m_{W}\geq100$} & \multicolumn{3}{c|}{total} & \multicolumn{3}{c}{$m_{W}<100$} & \multicolumn{3}{c|}{$m_{W}\geq100$} & \multicolumn{3}{c|}{$\\frac{m_{W}\geq100}{m_{W}<100}$}\\\ '
 secondLine = False
 for srNJet in sorted(signalRegions):
   print '\\hline'
@@ -261,14 +261,21 @@ for srNJet in sorted(signalRegions):
     for htb in sorted(signalRegions[srNJet][stb]):
       if not first: print '&'
       first = False
+      W_lowMass_lowDPhi = W_lowMass[srNJet][stb][htb]['yield_highDPhi']/W_lowMass[srNJet][stb][htb]['rcs']['rCS']
+      W_lowMass_lowDPhi_err = W_lowMass_lowDPhi*sqrt(W_lowMass[srNJet][stb][htb]['yield_highDPhi_Var']/W_lowMass[srNJet][stb][htb]['yield_highDPhi']**2 + W_lowMass[srNJet][stb][htb]['rcs']['rCSE_sim']**2/W_lowMass[srNJet][stb][htb]['rcs']['rCS']**2)
+      W_highMass_lowDPhi = W_highMass[srNJet][stb][htb]['yield_highDPhi']/W_highMass[srNJet][stb][htb]['rcs']['rCS']
+      W_highMass_lowDPhi_err = W_highMass_lowDPhi*sqrt(W_highMass[srNJet][stb][htb]['yield_highDPhi_Var']/W_highMass[srNJet][stb][htb]['yield_highDPhi']**2 + W_highMass[srNJet][stb][htb]['rcs']['rCSE_sim']**2/W_highMass[srNJet][stb][htb]['rcs']['rCS']**2)
+      
       print '&$'+varBin(htb)+'$'
       print ' & '+getNumString(W_lowMass[srNJet][stb][htb]['rcs']['rCS'], W_lowMass[srNJet][stb][htb]['rcs']['rCSE_sim'],3)\
           + ' & '+getNumString(W_highMass[srNJet][stb][htb]['rcs']['rCS'], W_highMass[srNJet][stb][htb]['rcs']['rCSE_sim'],3)\
           + ' & '+getNumString(W_lowMass[srNJet][stb][htb]['rcs_total']['rCS'], W_lowMass[srNJet][stb][htb]['rcs_total']['rCSE_sim'],3)\
+          + ' & '+getNumString(W_lowMass_lowDPhi,W_lowMass_lowDPhi_err)\
+          + ' & '+getNumString(W_highMass_lowDPhi,W_highMass_lowDPhi_err)\
           + ' & '+getNumString(W_lowMass[srNJet][stb][htb]['yield_highDPhi'], sqrt(W_lowMass[srNJet][stb][htb]['yield_highDPhi_Var']))\
           + ' & '+getNumString(W_highMass[srNJet][stb][htb]['yield_highDPhi'], sqrt(W_highMass[srNJet][stb][htb]['yield_highDPhi_Var']))\
           + ' & '+getNumString(W_lowMass[srNJet][stb][htb]['mass_ratio']['rCS'], W_lowMass[srNJet][stb][htb]['mass_ratio']['rCSE_sim'])+'\\\\ '
-    if htb[1] == -1 : print '\\cline{2-21}'
+    if htb[1] == -1 : print '\\cline{2-27}'
 print '\\hline\end{tabular}}\end{center}\caption{\Rcs values of different masses of W bosons, W+Jets background, 3$fb^{-1}$}\label{tab:0b_Wmass}\end{table}'
 
 

--- a/RA4Analysis/plotsDaniel/helpers.py
+++ b/RA4Analysis/plotsDaniel/helpers.py
@@ -1,0 +1,19 @@
+def filterParticles(l, values, attribute):
+  for a in l:
+    for v in values:
+      if abs(a[attribute])==v: yield a
+
+def dictDepth(d, depth=0):
+  if not isinstance(d, dict) or not d:
+    return depth
+  return max(dictDepth(v, depth+1) for k, v in d.iteritems())
+
+def addKey(d, newDict='deltaPhiCut'):
+  for k, v in d.iteritems():
+    if k == newDict:
+      d = {d[k]:d}
+      return d
+    elif isinstance(v, dict):
+      d[k] = addKey(v, newDict)
+  return d
+

--- a/RA4Analysis/plotsDaniel/plot.py
+++ b/RA4Analysis/plotsDaniel/plot.py
@@ -41,7 +41,7 @@ WJETSbtagweight = {'name':'WJets', 'chain':getChain(WJetsHT_25ns_btagweight,hist
 WJETS = {'name':'WJets', 'chain':getChain(WJetsHT_25ns,histname=''), 'color':color('WJets'),'weight':'weight', 'niceName':'W Jets CB ID'}
 #TTJETS = {'name':'TTJets', 'chain':getChain(TTJets_25ns,histname=''), 'color':color('TTJets'),'weight':'weight', 'niceName':'t#bar{t} Jets NLO'}
 #TTJetsLO = {'name':'TTJets', 'chain':getChain(TTJets_LO_25ns,histname=''), 'color':color('singleTop'),'weight':'weight', 'niceName':'t#bar{t} Jets MVA ID'}
-TTJetsbtagweight = {'name':'TTJets', 'chain':getChain(TTJets_LO_25ns_btagweight,histname=''), 'color':color('singleTop'),'weight':'weight', 'niceName':'t#bar{t} Jets btag'}
+TTJetsbtagweight = {'name':'TTJets', 'chain':getChain(TTJets_HTLO_25ns_btagweight,histname=''), 'color':color('singleTop'),'weight':'weight', 'niceName':'t#bar{t} Jets btag'}
 TTJets = {'name':'TTJets', 'chain':getChain(TTJets_HTLO_25ns,histname=''), 'color':color('TTJets')-2,'weight':'weight', 'niceName':'t#bar{t} Jets CB ID'}
 DY = {'name':'DY', 'chain':getChain(DY_25ns,histname=''), 'color':color('DY'),'weight':'weight', 'niceName':'Drell Yan'}
 singleTop = {'name':'singleTop', 'chain':getChain(singleTop_25ns,histname=''), 'color':color('singleTop'),'weight':'weight', 'niceName':'single Top'}

--- a/RA4Analysis/python/cmgTuples_Spring15_25ns_HT500ST250_postProcessed_btagWeight.py
+++ b/RA4Analysis/python/cmgTuples_Spring15_25ns_HT500ST250_postProcessed_btagWeight.py
@@ -2,7 +2,7 @@ import copy, os, sys
 dirDaniel = '/data/dspitzbart/cmgTuples/postProcessed_Spring15_CB/HT400ST200/hard/'
 dirNew = '/data/dspitzbart/cmgTuples/postProcessed_PUreweight/HT500ST250/hard/'
 
-TTJets_LO_25ns_btagweight={\
+TTJets_HTLO_25ns_btagweight={\
 "name" : "tt+Jets_LO",
 "bins" : [
 "TTJets_LO_25ns",

--- a/RA4Analysis/rCS/binnedNBTagsFit.py
+++ b/RA4Analysis/rCS/binnedNBTagsFit.py
@@ -22,21 +22,21 @@ def binnedNBTagsFit(cut, cutname, samples, prefix = "", QCD_dict={0:{'y':0.,'e':
   cRest = samples['Rest']
   cData = samples['Data']
   
-  #templateLumi = 1.26
   errorScale = 1
   if errorScale != 1:
     print '############################## DANGER! ERROR IN TEMPLATE DOWNSCALED! DANGER! ##################################################################################'
   
-  if isData: w = weight_str
-  else: w = 'weight'
+  if isData: w = 'weight'
+  else: w = weight_str
   
   hQCD = ROOT.TH1F('hQCD','hQCD',len([0,1,2,3])-1, array('d',[0,1,2,3]))
   for n in range(3):
-    if isnan(QCD_dict[n]['y']): QCD_dict[n]['y'] = QCD_dict[n]['totalY']
-    hQCD.SetBinContent(n+1,QCD_dict[n]['y']/2) #divide by 2 to split in +/- charge
-    if isnan(QCD_dict[n]['e']): qcdErr = QCD_dict[n]['y']
+    if isnan(QCD_dict[n]['y']): QCD_dict[n]['y'] = QCD_dict[n]['totalY'] #if lowDPhi QCD pred is nan, use total QCD pred (which should be 0 then)
+    hQCD.SetBinContent(n+1,QCD_dict[n]['y'])
+    if isnan(QCD_dict[n]['e']): qcdErr = QCD_dict[n]['y'] #if QCD pred error is nan set the error to 100%
     else: qcdErr = QCD_dict[n]['e']
-    hQCD.SetBinError(n+1,qcdErr/2)
+    hQCD.SetBinError(n+1,qcdErr)
+  hQCD.Scale(0.5) #split in +/- charge
   
   #Get histograms binned in b-tag multiplicity
   template_WJets_PosPdg_Dict = getTemplate(cutname, templateDir, 'WJets_PosPdg') #these templates will always be MC, so a reweighting (e.g. b-tagging) should not be used
@@ -50,8 +50,8 @@ def binnedNBTagsFit(cut, cutname, samples, prefix = "", QCD_dict={0:{'y':0.,'e':
       template_WJets_PosPdg.SetBinError(1,  errorScale*sqrt(getYieldFromChain(cWJets, cutString = 'leptonPdg>0&&'+cut, weight = weight_err_str+'*weightBTag0'+templateWeightSuffix+'**2')))
       template_WJets_PosPdg.SetBinContent(2,getYieldFromChain(cWJets, cutString = 'leptonPdg>0&&'+cut, weight = weight_str+'*weightBTag1'+templateWeightSuffix))
       template_WJets_PosPdg.SetBinError(2,  errorScale*sqrt(getYieldFromChain(cWJets, cutString = 'leptonPdg>0&&'+cut, weight = weight_err_str+'*weightBTag1'+templateWeightSuffix+'**2')))
-      template_WJets_PosPdg.SetBinContent(3,getYieldFromChain(cWJets, cutString = 'leptonPdg>0&&'+cut, weight = weight_str+'*weightBTag2'+templateWeightSuffix))
-      template_WJets_PosPdg.SetBinError(3,  errorScale*sqrt(getYieldFromChain(cWJets, cutString = 'leptonPdg>0&&'+cut, weight = weight_err_str+'*weightBTag2'+templateWeightSuffix+'**2')))
+      template_WJets_PosPdg.SetBinContent(3,getYieldFromChain(cWJets, cutString = 'leptonPdg>0&&'+cut, weight = weight_str+'*weightBTag2p'+templateWeightSuffix))
+      template_WJets_PosPdg.SetBinError(3,  errorScale*sqrt(getYieldFromChain(cWJets, cutString = 'leptonPdg>0&&'+cut, weight = weight_err_str+'*weightBTag2p'+templateWeightSuffix+'**2')))
     tempFile_WJets_PosPdg = ROOT.TFile(templateDir+cutname+'_WJets_PosPdg.root','new')
     template_WJets_PosPdg.Write()
     #tempFile.Close()
@@ -67,8 +67,8 @@ def binnedNBTagsFit(cut, cutname, samples, prefix = "", QCD_dict={0:{'y':0.,'e':
       template_WJets_NegPdg.SetBinError(1,  errorScale*sqrt(getYieldFromChain(cWJets, cutString = 'leptonPdg<0&&'+cut, weight = weight_err_str+'*weightBTag0'+templateWeightSuffix+'**2')))
       template_WJets_NegPdg.SetBinContent(2,getYieldFromChain(cWJets, cutString = 'leptonPdg<0&&'+cut, weight = weight_str+'*weightBTag1'+templateWeightSuffix))
       template_WJets_NegPdg.SetBinError(2,  errorScale*sqrt(getYieldFromChain(cWJets, cutString = 'leptonPdg<0&&'+cut, weight = weight_err_str+'*weightBTag1'+templateWeightSuffix+'**2')))
-      template_WJets_NegPdg.SetBinContent(3,getYieldFromChain(cWJets, cutString = 'leptonPdg<0&&'+cut, weight = weight_str+'*weightBTag2'+templateWeightSuffix))
-      template_WJets_NegPdg.SetBinError(3,  errorScale*sqrt(getYieldFromChain(cWJets, cutString = 'leptonPdg<0&&'+cut, weight = weight_err_str+'*weightBTag2'+templateWeightSuffix+'**2')))
+      template_WJets_NegPdg.SetBinContent(3,getYieldFromChain(cWJets, cutString = 'leptonPdg<0&&'+cut, weight = weight_str+'*weightBTag2p'+templateWeightSuffix))
+      template_WJets_NegPdg.SetBinError(3,  errorScale*sqrt(getYieldFromChain(cWJets, cutString = 'leptonPdg<0&&'+cut, weight = weight_err_str+'*weightBTag2p'+templateWeightSuffix+'**2')))
     tempFile_WJets_NegPdg = ROOT.TFile(templateDir+cutname+'_WJets_NegPdg.root','new')
     template_WJets_NegPdg.Write()
     #tempFile.Close()
@@ -84,8 +84,8 @@ def binnedNBTagsFit(cut, cutname, samples, prefix = "", QCD_dict={0:{'y':0.,'e':
       template_TTJets.SetBinError(1,  errorScale*sqrt(getYieldFromChain(cTTJets, cutString = cut, weight = weight_err_str+'*weightBTag0'+templateWeightSuffix+'**2')))
       template_TTJets.SetBinContent(2,getYieldFromChain(cTTJets, cutString = cut, weight = weight_str+'*weightBTag1'+templateWeightSuffix))
       template_TTJets.SetBinError(2,  errorScale*sqrt(getYieldFromChain(cTTJets, cutString = cut, weight = weight_err_str+'*weightBTag1'+templateWeightSuffix+'**2')))
-      template_TTJets.SetBinContent(3,getYieldFromChain(cTTJets, cutString = cut, weight = weight_str+'*weightBTag2'+templateWeightSuffix))
-      template_TTJets.SetBinError(3,  errorScale*sqrt(getYieldFromChain(cTTJets, cutString = cut, weight = weight_err_str+'*weightBTag2'+templateWeightSuffix+'**2')))
+      template_TTJets.SetBinContent(3,getYieldFromChain(cTTJets, cutString = cut, weight = weight_str+'*weightBTag2p'+templateWeightSuffix))
+      template_TTJets.SetBinError(3,  errorScale*sqrt(getYieldFromChain(cTTJets, cutString = cut, weight = weight_err_str+'*weightBTag2p'+templateWeightSuffix+'**2')))
     tempFile_TTJets = ROOT.TFile(templateDir+cutname+'_TTJets.root','new')
     template_TTJets.Write()
     #tempFile.Close()
@@ -143,18 +143,18 @@ def binnedNBTagsFit(cut, cutname, samples, prefix = "", QCD_dict={0:{'y':0.,'e':
     
     bin3 = hData_PosPdg.GetBinContent(3)
     bin3Var = (hData_PosPdg.GetBinError(3))**2
-    bin3    += getYieldFromChain(cWJets, cutString =   'leptonPdg>0&&'+cut, weight = weight_str+'*weightBTag2'+btagWeightSuffix)
-    bin3Var += getYieldFromChain(cWJets, cutString =   'leptonPdg>0&&'+cut, weight = weight_err_str+'*weightBTag2'+btagWeightSuffix+'**2')
-    bin3    += getYieldFromChain(cTTJets, cutString =  'leptonPdg>0&&'+cut, weight = weight_str+'*weightBTag2'+btagWeightSuffix)
-    bin3Var += getYieldFromChain(cTTJets, cutString =   'leptonPdg>0&&'+cut, weight = weight_err_str+'*weightBTag2'+btagWeightSuffix+'**2')
+    bin3    += getYieldFromChain(cWJets, cutString =   'leptonPdg>0&&'+cut, weight = weight_str+'*weightBTag2p'+btagWeightSuffix)
+    bin3Var += getYieldFromChain(cWJets, cutString =   'leptonPdg>0&&'+cut, weight = weight_err_str+'*weightBTag2p'+btagWeightSuffix+'**2')
+    bin3    += getYieldFromChain(cTTJets, cutString =  'leptonPdg>0&&'+cut, weight = weight_str+'*weightBTag2p'+btagWeightSuffix)
+    bin3Var += getYieldFromChain(cTTJets, cutString =   'leptonPdg>0&&'+cut, weight = weight_err_str+'*weightBTag2p'+btagWeightSuffix+'**2')
     hData_PosPdg.SetBinContent(3,bin3)
     hData_PosPdg.SetBinError(3,sqrt(bin3Var))
     #hData_PosPdg.Fill(0,getYieldFromChain(cWJets, cutString =   'leptonPdg>0&&'+cut, weight = weight_str+'*weightBTag0'+btagWeightSuffix))
     #hData_PosPdg.Fill(1,getYieldFromChain(cWJets, cutString =   'leptonPdg>0&&'+cut, weight = weight_str+'*weightBTag1'+btagWeightSuffix))
-    #hData_PosPdg.Fill(2,getYieldFromChain(cWJets, cutString =   'leptonPdg>0&&'+cut, weight = weight_str+'*weightBTag2'+btagWeightSuffix))
+    #hData_PosPdg.Fill(2,getYieldFromChain(cWJets, cutString =   'leptonPdg>0&&'+cut, weight = weight_str+'*weightBTag2p'+btagWeightSuffix))
     #hData_PosPdg.Fill(0,getYieldFromChain(cTTJets, cutString =  'leptonPdg>0&&'+cut, weight = weight_str+'*weightBTag0'+btagWeightSuffix))
     #hData_PosPdg.Fill(1,getYieldFromChain(cTTJets, cutString =  'leptonPdg>0&&'+cut, weight = weight_str+'*weightBTag1'+btagWeightSuffix))
-    #hData_PosPdg.Fill(2,getYieldFromChain(cTTJets, cutString =  'leptonPdg>0&&'+cut, weight = weight_str+'*weightBTag2'+btagWeightSuffix))
+    #hData_PosPdg.Fill(2,getYieldFromChain(cTTJets, cutString =  'leptonPdg>0&&'+cut, weight = weight_str+'*weightBTag2p'+btagWeightSuffix))
     
     hData_NegPdg = getPlotFromChain(cRest, nBTagVar, [0,1,2,3], 'leptonPdg<0&&'+cut, weight_str, binningIsExplicit=True,addOverFlowBin='upper')
     #hData_NegPdg.Sumw2()
@@ -178,25 +178,25 @@ def binnedNBTagsFit(cut, cutname, samples, prefix = "", QCD_dict={0:{'y':0.,'e':
 
     bin3 = hData_NegPdg.GetBinContent(3)
     bin3Var = (hData_NegPdg.GetBinError(3))**2
-    bin3    += getYieldFromChain(cWJets, cutString =   'leptonPdg<0&&'+cut, weight = weight_str+'*weightBTag2'+btagWeightSuffix)
-    bin3Var += getYieldFromChain(cWJets, cutString =   'leptonPdg<0&&'+cut, weight = weight_err_str+'*weightBTag2'+btagWeightSuffix+'**2')
-    bin3    += getYieldFromChain(cTTJets, cutString =  'leptonPdg<0&&'+cut, weight = weight_str+'*weightBTag2'+btagWeightSuffix)
-    bin3Var += getYieldFromChain(cTTJets, cutString =  'leptonPdg<0&&'+cut, weight = weight_err_str+'*weightBTag2'+btagWeightSuffix+'**2')
+    bin3    += getYieldFromChain(cWJets, cutString =   'leptonPdg<0&&'+cut, weight = weight_str+'*weightBTag2p'+btagWeightSuffix)
+    bin3Var += getYieldFromChain(cWJets, cutString =   'leptonPdg<0&&'+cut, weight = weight_err_str+'*weightBTag2p'+btagWeightSuffix+'**2')
+    bin3    += getYieldFromChain(cTTJets, cutString =  'leptonPdg<0&&'+cut, weight = weight_str+'*weightBTag2p'+btagWeightSuffix)
+    bin3Var += getYieldFromChain(cTTJets, cutString =  'leptonPdg<0&&'+cut, weight = weight_err_str+'*weightBTag2p'+btagWeightSuffix+'**2')
     hData_NegPdg.SetBinContent(3,bin3)
     hData_NegPdg.SetBinError(3,sqrt(bin3Var))
     #hData_NegPdg.Fill(0,getYieldFromChain(cWJets, cutString =   'leptonPdg<0&&'+cut, weight = weight_str+'*weightBTag0'+btagWeightSuffix))
     #hData_NegPdg.Fill(1,getYieldFromChain(cWJets, cutString =   'leptonPdg<0&&'+cut, weight = weight_str+'*weightBTag1'+btagWeightSuffix))
-    #hData_NegPdg.Fill(2,getYieldFromChain(cWJets, cutString =   'leptonPdg<0&&'+cut, weight = weight_str+'*weightBTag2'+btagWeightSuffix))
+    #hData_NegPdg.Fill(2,getYieldFromChain(cWJets, cutString =   'leptonPdg<0&&'+cut, weight = weight_str+'*weightBTag2p'+btagWeightSuffix))
     #hData_NegPdg.Fill(0,getYieldFromChain(cTTJets, cutString =  'leptonPdg<0&&'+cut, weight = weight_str+'*weightBTag0'+btagWeightSuffix))
     #hData_NegPdg.Fill(1,getYieldFromChain(cTTJets, cutString =  'leptonPdg<0&&'+cut, weight = weight_str+'*weightBTag1'+btagWeightSuffix))
-    #hData_NegPdg.Fill(2,getYieldFromChain(cTTJets, cutString =  'leptonPdg<0&&'+cut, weight = weight_str+'*weightBTag2'+btagWeightSuffix))
+    #hData_NegPdg.Fill(2,getYieldFromChain(cTTJets, cutString =  'leptonPdg<0&&'+cut, weight = weight_str+'*weightBTag2p'+btagWeightSuffix))
 
   ##### use this for DATA
   else:
     hData_PosPdg = getPlotFromChain(cData, nBTagVar, [0,1,2,3], 'leptonPdg>0&&'+cut, w, binningIsExplicit=True,addOverFlowBin='upper')
     hData_NegPdg = getPlotFromChain(cData, nBTagVar, [0,1,2,3], 'leptonPdg<0&&'+cut, w, binningIsExplicit=True,addOverFlowBin='upper')
-    hData_PosPdg.Add(hQCD,-1)
-    hData_NegPdg.Add(hQCD,-1)
+    #hData_PosPdg.Add(hQCD,-1)
+    #hData_NegPdg.Add(hQCD,-1)
   hData_PosPdg_File = ROOT.TFile(templateDir+cutname+'_PosPdg_DataHist.root','new')
   hData_PosPdg.Write()
   hData_NegPdg_File = ROOT.TFile(templateDir+cutname+'_NegPdg_DataHist.root','new')
@@ -233,6 +233,7 @@ def binnedNBTagsFit(cut, cutname, samples, prefix = "", QCD_dict={0:{'y':0.,'e':
   print "template_TTJets:" ,       template_TTJets.Integral()
   print "template_Rest_PosPdg:" ,  template_Rest_PosPdg.Integral()
   print "template_Rest_NegPdg:" ,  template_Rest_NegPdg.Integral()
+  print "QCD yield", hQCD.Integral()
 
   #Normalize histograms
   template_TTJets.Scale(1./template_TTJets.Integral())
@@ -242,6 +243,8 @@ def binnedNBTagsFit(cut, cutname, samples, prefix = "", QCD_dict={0:{'y':0.,'e':
   y_Rest_NegPdg = template_Rest_NegPdg.Integral()*lumi/templateLumi
   template_Rest_PosPdg.Scale(1./template_Rest_PosPdg.Integral())
   template_Rest_NegPdg.Scale(1./template_Rest_NegPdg.Integral())
+  y_QCD = hQCD.Integral()
+  if y_QCD > 0: hQCD.Scale(1./hQCD.Integral()) 
   #hData_PosPdg.Scale(1./hData_PosPdg.Integral())
   #hData_NegPdg.Scale(1./hData_NegPdg.Integral())
   #Observable
@@ -256,8 +259,12 @@ def binnedNBTagsFit(cut, cutname, samples, prefix = "", QCD_dict={0:{'y':0.,'e':
   dh_TTJets=ROOT.RooDataHist("mcTTJets","mcTTJets",ROOT.RooArgList(x),template_TTJets)
   dh_Rest_PosPdg=ROOT.RooDataHist("mcRest","mcRest",ROOT.RooArgList(x),template_Rest_PosPdg)
   dh_Rest_NegPdg=ROOT.RooDataHist("mcRest","mcRest",ROOT.RooArgList(x),template_Rest_NegPdg)
+  if y_QCD > 0:
+    dh_QCD=ROOT.RooDataHist("predQCD","predQCD",ROOT.RooArgList(x),hQCD)
+    rooDataHist_arr = [data_NegPdg , data_PosPdg , dh_WJets_PosPdg , dh_WJets_NegPdg , dh_TTJets , dh_Rest_PosPdg , dh_Rest_NegPdg, dh_QCD]
+  else:
+    rooDataHist_arr = [data_NegPdg , data_PosPdg , dh_WJets_PosPdg , dh_WJets_NegPdg , dh_TTJets , dh_Rest_PosPdg , dh_Rest_NegPdg]
 
-  rooDataHist_arr = [data_NegPdg , data_PosPdg , dh_WJets_PosPdg , dh_WJets_NegPdg , dh_TTJets , dh_Rest_PosPdg , dh_Rest_NegPdg]
   print "write RooDataHist values bin by bin"
   for hist in rooDataHist_arr:
     print "roo data hist: " , hist.Print()
@@ -275,6 +282,9 @@ def binnedNBTagsFit(cut, cutname, samples, prefix = "", QCD_dict={0:{'y':0.,'e':
   yield_Rest_NegPdg = ROOT.RooRealVar("yield_Rest_NegPdg","yield_Rest_NegPdg",y_Rest_NegPdg,y_Rest_NegPdg,y_Rest_NegPdg)
   yield_Rest_PosPdg.setConstant()
   yield_Rest_NegPdg.setConstant()
+  if y_QCD > 0:
+    yield_QCD = ROOT.RooRealVar("yield_QCD","yield_QCD",y_QCD,y_QCD,y_QCD)
+    yield_QCD.setConstant()
 
   print "BEFORE FIT YIELDS:"
   print "yield_WJets_NegPdg:" , yield_WJets_NegPdg.getVal()
@@ -288,12 +298,17 @@ def binnedNBTagsFit(cut, cutname, samples, prefix = "", QCD_dict={0:{'y':0.,'e':
   model_TTJets=ROOT.RooHistPdf("model_TTJets","model_TTJets",ROOT.RooArgSet(x),dh_TTJets)
   model_Rest_PosPdg=ROOT.RooHistPdf("model_Rest_PosPdg","model_Rest_PosPdg",ROOT.RooArgSet(x),dh_Rest_PosPdg)
   model_Rest_NegPdg=ROOT.RooHistPdf("model_Rest_NegPdg","model_Rest_NegPdg",ROOT.RooArgSet(x),dh_Rest_NegPdg)
+  if y_QCD > 0: model_QCD=ROOT.RooHistPdf("model_QCD","model_QCD",ROOT.RooArgSet(x),dh_QCD)
 
   #Make combined PDF of all MC Backgrounds
 #  model_PosPdg=ROOT.RooAddPdf("model_PosPdg","model_PosPdg",ROOT.RooArgList(model_WJets_PosPdg, model_TTJets),ROOT.RooArgList(yield_WJets_PosPdg, yield_TTJets))
 #  model_NegPdg=ROOT.RooAddPdf("model_NegPdg","model_NegPdg",ROOT.RooArgList(model_WJets_NegPdg, model_TTJets),ROOT.RooArgList(yield_WJets_NegPdg, yield_TTJets))
-  model_PosPdg=ROOT.RooAddPdf("model_PosPdg","model_PosPdg",ROOT.RooArgList(model_WJets_PosPdg, model_TTJets, model_Rest_PosPdg),ROOT.RooArgList(yield_WJets_PosPdg, yield_TTJets, yield_Rest_PosPdg))
-  model_NegPdg=ROOT.RooAddPdf("model_NegPdg","model_NegPdg",ROOT.RooArgList(model_WJets_NegPdg, model_TTJets, model_Rest_NegPdg),ROOT.RooArgList(yield_WJets_NegPdg, yield_TTJets, yield_Rest_NegPdg))
+  if y_QCD > 0:
+    model_PosPdg=ROOT.RooAddPdf("model_PosPdg","model_PosPdg",ROOT.RooArgList(model_WJets_PosPdg, model_TTJets, model_Rest_PosPdg, model_QCD),ROOT.RooArgList(yield_WJets_PosPdg, yield_TTJets, yield_Rest_PosPdg, yield_QCD))
+    model_NegPdg=ROOT.RooAddPdf("model_NegPdg","model_NegPdg",ROOT.RooArgList(model_WJets_NegPdg, model_TTJets, model_Rest_NegPdg, model_QCD),ROOT.RooArgList(yield_WJets_NegPdg, yield_TTJets, yield_Rest_NegPdg, yield_QCD))
+  else:
+    model_PosPdg=ROOT.RooAddPdf("model_PosPdg","model_PosPdg",ROOT.RooArgList(model_WJets_PosPdg, model_TTJets, model_Rest_PosPdg),ROOT.RooArgList(yield_WJets_PosPdg, yield_TTJets, yield_Rest_PosPdg))
+    model_NegPdg=ROOT.RooAddPdf("model_NegPdg","model_NegPdg",ROOT.RooArgList(model_WJets_NegPdg, model_TTJets, model_Rest_NegPdg),ROOT.RooArgList(yield_WJets_NegPdg, yield_TTJets, yield_Rest_NegPdg))
   #CombinesmyMCsintoonePDFmodel
 
   #Plot the imported histogram(s)
@@ -314,7 +329,9 @@ def binnedNBTagsFit(cut, cutname, samples, prefix = "", QCD_dict={0:{'y':0.,'e':
   frame_Rest_NegPdg=x.frame(rf.Title("Rest NegPdg"))
   model_Rest_NegPdg.plotOn(frame_Rest_NegPdg)
 
-  
+  if y_QCD > 0:
+    frame_QCD=x.frame(rf.Title("QCD"))
+    model_QCD.plotOn(frame_QCD)
 
 #  c=ROOT.TCanvas("roofit_example","RooFitFractionFitExample",800,1200)
 #  c.Divide(1,3)
@@ -365,6 +382,7 @@ def binnedNBTagsFit(cut, cutname, samples, prefix = "", QCD_dict={0:{'y':0.,'e':
   model_PosPdg.plotOn(fitFrame_PosPdg,rf.Components("model_WJets_PosPdg"),rf.LineColor(ROOT.kGreen))
   model_PosPdg.plotOn(fitFrame_PosPdg,rf.Components("model_TTJets"),rf.LineColor(ROOT.kBlue))
   model_PosPdg.plotOn(fitFrame_PosPdg,rf.Components("model_Rest_PosPdg"),rf.LineColor(ROOT.kOrange+7))
+  if y_QCD > 0: model_PosPdg.plotOn(fitFrame_PosPdg,rf.Components("model_QCD"),rf.LineColor(color('QCD')))
 
   fitFrame_NegPdg=x.frame(rf.Bins(50),rf.Title("FitModel"))
   model_NegPdg.paramOn(fitFrame_NegPdg,rf.Layout(0.42,0.9,0.9))
@@ -373,6 +391,7 @@ def binnedNBTagsFit(cut, cutname, samples, prefix = "", QCD_dict={0:{'y':0.,'e':
   model_NegPdg.plotOn(fitFrame_NegPdg,rf.Components("model_WJets_NegPdg"),rf.LineColor(ROOT.kGreen))
   model_NegPdg.plotOn(fitFrame_NegPdg,rf.Components("model_TTJets"),rf.LineColor(ROOT.kBlue))
   model_NegPdg.plotOn(fitFrame_NegPdg,rf.Components("model_Rest_NegPdg"),rf.LineColor(ROOT.kOrange+7))
+  if y_QCD > 0: model_NegPdg.plotOn(fitFrame_NegPdg,rf.Components("model_QCD"),rf.LineColor(color('QCD')))
 
   print "After Fitting:"
   for data_hists in [data_NegPdg , data_PosPdg]:
@@ -387,9 +406,9 @@ def binnedNBTagsFit(cut, cutname, samples, prefix = "", QCD_dict={0:{'y':0.,'e':
   print "yield_TTJets:" , yield_TTJets.getVal()
   print "yield_Rest_PosPdg:" , yield_Rest_PosPdg.getVal()
   print "yield_Rest_NegPdg:" , yield_Rest_NegPdg.getVal()
+  if y_QCD > 0: print "yield_QCD:", yield_QCD.getVal()
 
-
-  c1=ROOT.TCanvas("c1","FitModel",800,1200)
+  c1=ROOT.TCanvas("c1","FitModel",650,1000)
   ROOT.gROOT.SetStyle("Plain")
   c1.Divide(1,2)
   c1.cd(1)

--- a/RA4Analysis/rCS/binnedNBTagsFit.py
+++ b/RA4Analysis/rCS/binnedNBTagsFit.py
@@ -8,19 +8,21 @@ from Workspace.HEPHYPythonTools.user import username
 from math import pi, sqrt, isnan
 from rCShelpers import *# weight_str , weight_err_str , lumi
 
-def binnedNBTagsFit(cut, cutname, samples, nBTagVar = 'nBJetMediumCSV30', lumi=4.0, prefix="", printDir='/afs/hephy.at/user/'+username[0]+'/'+username+'/www/Spring15/nBtagFits/templateFit/', templateDir = '/data/'+username+'/Results2015/btagTemplatesBTagWeightedSF_forData_FullSR_Lep/',useBTagWeights=False, btagWeightSuffix='', templateWeights=False, templateWeightSuffix='', QCD_dict={0:{'y':0.,'e':0.,'totalY':0.}, 1:{'y':0.,'e':0.,'totalY':0.},2:{'y':0.,'e':0.,'totalY':0.}}, isData=False):
-  print "LUMI:" , lumi
-  if not os.path.exists(printDir):
-     os.makedirs(printDir) 
-  if not os.path.exists(templateDir):
-     os.makedirs(templateDir)
-  weight_str, weight_err_str = makeWeight(lumi)
+from predictionConfig import *
+
+def binnedNBTagsFit(cut, cutname, samples, prefix = "", QCD_dict={0:{'y':0.,'e':0.,'totalY':0.}, 1:{'y':0.,'e':0.,'totalY':0.},2:{'y':0.,'e':0.,'totalY':0.}}):
+  #print "LUMI:" , lumi
+  #if not os.path.exists(printDir):
+  #   os.makedirs(printDir) 
+  #if not os.path.exists(templateDir):
+  #   os.makedirs(templateDir)
+  weight_str, weight_err_str = makeWeight(lumi, sampleLumi)
   cWJets = samples['W']
   cTTJets = samples['TT']
   cRest = samples['Rest']
   cData = samples['Data']
   
-  templateLumi = 1.26
+  #templateLumi = 1.26
   errorScale = 1
   if errorScale != 1:
     print '############################## DANGER! ERROR IN TEMPLATE DOWNSCALED! DANGER! ##################################################################################'

--- a/RA4Analysis/rCS/makePrediction.py
+++ b/RA4Analysis/rCS/makePrediction.py
@@ -3,15 +3,6 @@ import pickle
 import os,sys
 from Workspace.HEPHYPythonTools.helpers import getChain, getPlotFromChain, getYieldFromChain
 from Workspace.RA4Analysis.helpers import nameAndCut, nJetBinName,nBTagBinName,varBinName
-#from Workspace.RA4Analysis.cmgTuplesPostProcessed_v8_Phys14V3_HT400ST200 import *
-#from Workspace.RA4Analysis.cmgTuplesPostProcessed_v9_Phys14V3_HT400ST200_ForTTJetsUnc import *
-#from Workspace.RA4Analysis.cmgTuplesPostProcessed_Spring15_hard import *
-#from Workspace.RA4Analysis.cmgTuples_Spring15_25ns_postProcessed import *
-#from Workspace.RA4Analysis.cmgTuples_Spring15_25ns_postProcessed_fromArtur import *
-
-from Workspace.RA4Analysis.cmgTuples_Spring15_25ns_HT500ST250_postProcessed_btagWeight import *
-from Workspace.RA4Analysis.cmgTuples_Spring15_25ns_HT500ST250_postProcessed_fromArthur import *
-
 
 from makeTTPrediction import makeTTPrediction
 from makeWPrediction import makeWPrediction
@@ -21,52 +12,16 @@ from rCShelpers import *
 from math import pi, sqrt
 from Workspace.RA4Analysis.signalRegions import *
 
+from predictionConfig import *
+
 ROOT.TH1F().SetDefaultSumw2()
 
-lepSel = 'hard'
-
-cWJets  = getChain(WJetsHT_25ns_btagweight,histname='')
-cTTJets = getChain(TTJets_LO_25ns_btagweight,histname='')
-cRest = getChain([singleTop_25ns, DY_25ns, TTV_25ns],histname='')#no QCD
-cBkg =  getChain([WJetsHT_25ns_btagweight, TTJets_LO_25ns_btagweight, singleTop_25ns, DY_25ns, TTV_25ns], histname='')#no QCD
-#cData = getChain([WJetsHT_25ns_btagweight, TTJets_LO_25ns_btagweight, singleTop_25ns, DY_25ns, TTV_25ns], histname='')
-cData = getChain([SingleMuon_Run2015D, SingleElectron_Run2015D], histname='')
-
-#cBkg = getChain([WJetsHTToLNu[lepSel], ttJets[lepSel], DY[lepSel], singleTop[lepSel], TTVH[lepSel]],histname='')#no QCD
-#cData = getChain([WJetsHTToLNu[lepSel], ttJets[lepSel], DY[lepSel], singleTop[lepSel], TTVH[lepSel]] , histname='')
-#cData = getChain([WJetsHTToLNu[lepSel], ttJets[lepSel], DY[lepSel], singleTop[lepSel], TTVH[lepSel]],  ttJets[lepSel] , histname='')#no QCD , ##to calculate signal contamination
-#cData = cBkg
-
-signalRegions = signalRegion3fb
-#signalRegions = signalRegionCRonly
-
-
-small = False
-if small: signalRegions = smallRegion
-
-#DEFINE LUMI AND PLOTDIR
-lumi = 1.26
-sampleLumi = 3.
-debugReweighting = False
-
-printDir = '/afs/hephy.at/user/'+username[0]+'/'+username+'/www/Spring15/25ns/templateFit_bweightSFTemplate_Data_fullSR_lep_'+str(lumi)+'/'
-pickleDir = '/data/'+username+'/Results2015/Prediction_bweightSFTemplate_Data_fullSR_lep_'+str(lumi)+'/'
-
-isData = True
-#QCDpickle = '/data/dhandl/results2015/QCDEstimation/20151027_QCDestimation_firstTry_pkl'
-QCDpickle = '/data/dhandl/results2015/QCDEstimation/20151106_QCDestimation_pkl'
-QCDestimate = pickle.load(file(QCDpickle))
-#QCDestimate=False
-
-if not os.path.exists(pickleDir):
-  os.makedirs(pickleDir)
-if not os.path.exists(printDir):
-  os.makedirs(printDir)
-
-weight_str, weight_err_str = makeWeight(lumi, sampleLumi=sampleLumi, debug=debugReweighting)
+weight_str, weight_err_str = makeWeight(lumi, sampleLumi=sampleLumi)
 
 samples={'W':cWJets, 'TT':cTTJets, 'Rest':cRest, 'Bkg':cBkg, 'Data': cData}
+
 signal = False
+lepSel = 'hard'
 if signal:
   allSignals=[
             {'name':'T5q^{4} 1.2/1.0/0.8', 'sample':T5qqqqWW_mGo1200_mCh1000_mChi800[lepSel], 'weight':weight_str, 'color':ROOT.kBlack},
@@ -76,29 +31,6 @@ if signal:
 
   for s in allSignals:
     s['chain'] = getChain(s['sample'],histname='')
-
-prefix = 'singleLeptonic_Spring15_'
-#presel = "singleLeptonic&&nLooseHardLeptons==1&&nTightHardLeptons==1&&nLooseSoftPt10Leptons==0&&Jet_pt[1]>80"#&&Flag_EcalDeadCellTriggerPrimitiveFilter&&acos(cos(Jet_phi[0]-met_phi))>0.45&&acos(cos(Jet_phi[1]-met_phi))>0.45"
-#presel = "singleLeptonic&&nLooseHardLeptons==1&&nTightHardLeptons==1&&nLooseSoftLeptons==0&&Jet_pt[1]>80"
-#presel = "singleLeptonic&&nLooseHardLeptons==1&&nTightHardLeptons==1&&Jet_pt[1]>80"
-#presel = "singleLeptonic&&nLooseHardLeptons==1&&nTightHardLeptons==1&&Jet_pt[1]>80&&st>250&&nJet30>2&&htJet30j>500"#&&nBJetMediumCSV30==0"
-#filters = "&&Flag_CSCTightHaloFilter&&Flag_HBHENoiseFilter&&Flag_goodVertices&&Flag_eeBadScFilter&&Flag_EcalDeadCellTriggerPrimitiveFilter"
-#presel = "singleLeptonic&&nLooseHardLeptons==1&&nTightHardLeptons==1&&nLooseSoftLeptons==0&&Jet_pt[1]>80&&st>250&&nJet30>2&&htJet30j>500"#&&nBJetMediumCSV30==0"
-#filters = "&&Flag_CSCTightHaloFilter&&Flag_HBHENoiseFilter&&Flag_goodVertices&&Flag_eeBadScFilter"#&&Flag_EcalDeadCellTriggerPrimitiveFilter" #strange filter settings!!
-
-triggers = "(HLT_EleHT350||HLT_MuHT350)"
-filters = "Flag_goodVertices && Flag_HBHENoiseFilter_fix && Flag_CSCTightHaloFilter && Flag_eeBadScFilter && Flag_HBHENoiseIsoFilter"
-presel = "((!isData&&singleLeptonic)||(isData&&"+triggers+"&&((muonDataSet&&singleMuonic)||(eleDataSet&&singleElectronic))&&"+filters+"))"
-presel += "&&nLooseHardLeptons==1&&nTightHardLeptons==1&&nLooseSoftLeptons==0&&Jet_pt[1]>80&&st>250&&nJet30>2&&htJet30j>500"
-
-
-btagString = 'nBJetMediumCSV30'
-useBTagWeights=False #True for weighted fake data, false for data
-btagWeightSuffix = ''
-templateWeights = True
-templateWeightSuffix = '_SF'
-
-bjreg = (0,0)
 
 bins = {}
 
@@ -116,10 +48,10 @@ for srNJet in signalRegions:
       print '## Using a dPhi cut value of',str(deltaPhiCut)
       print '#################################################'
       print
-      makeTTPrediction(rd, samples, htb, stb, srNJet, presel, dPhiCut=deltaPhiCut, btagVarString = btagString, lumi=lumi, printDir=printDir, useBTagWeights=useBTagWeights, btagWeightSuffix=btagWeightSuffix, templateWeights=templateWeights, templateWeightSuffix=templateWeightSuffix, QCD=QCDestimate, isData=isData)
+      makeTTPrediction(rd, samples, htb, stb, srNJet, presel, dPhiCut=deltaPhiCut, QCD=QCDestimate)
 
       #join W estimation results to dict
-      makeWPrediction(rd, samples, htb, stb, srNJet, presel, dPhiCut=deltaPhiCut, btagVarString = btagString, lumi=lumi, printDir=printDir, useBTagWeights=useBTagWeights, btagWeightSuffix=btagWeightSuffix, templateWeights=templateWeights, templateWeightSuffix=templateWeightSuffix, QCD=QCDestimate, isData=isData)
+      makeWPrediction(rd, samples, htb, stb, srNJet, presel, dPhiCut=deltaPhiCut, QCD=QCDestimate)
 
       ##If you want to make prediction of one of the bkgs, comment out all the estimation of total Bkgs
       #estimate total background
@@ -146,7 +78,7 @@ for srNJet in signalRegions:
                 'tot_NegPdg_truth':truth_total_NegPdg,'tot_NegPdg_truth_err':truth_total_NegPdg_err,\
                 })
 
-      name, cut =  nameAndCut(stb, htb, srNJet, btb=bjreg, presel=presel, btagVar = btagString)
+      name, cut =  nameAndCut(stb, htb, srNJet, btb=bjreg, presel=presel, btagVar = nBTagVar)
       if signal:
         for s in allSignals:
           s['yield_NegPdg']     = getYieldFromChain(s['chain'], 'leptonPdg<0&&'+cut+"&&deltaPhi_Wl>"+str(deltaPhiCut), weight = weight_str)

--- a/RA4Analysis/rCS/makeTTPrediction.py
+++ b/RA4Analysis/rCS/makeTTPrediction.py
@@ -7,13 +7,13 @@ from rCShelpers import *
 from math import pi, sqrt
 from rCShelpers import *
 
-dPhiStr='deltaPhi_Wl'
+from predictionConfig import *
 
 ROOT.TH1F().SetDefaultSumw2()
 
-def makeTTPrediction(bins, samples, htb, stb, srNJet, presel, dPhiCut=1.0, btagVarString = "nBJetMediumCSV30", lumi=4., printDir='/afs/hephy.at/user/'+username[0]+'/'+username+'/www/Spring15/defaultDir/templateFit/',useBTagWeights=False, btagWeightSuffix='', templateWeights=False, templateWeightSuffix='', QCD=False, isData=False):
-  print "in make tt prediction lumi is :" , lumi
-  weight_str, weight_err_str = makeWeight(lumi)
+def makeTTPrediction(bins, samples, htb, stb, srNJet, presel, dPhiCut=1.0, QCD=False):
+  #print "in make tt prediction lumi is :" , lumi
+  weight_str, weight_err_str = makeWeight(lumi, sampleLumi)
   cWJets = samples['W']
   cTTJets = samples['TT']
   cRest = samples['Rest']
@@ -29,16 +29,16 @@ def makeTTPrediction(bins, samples, htb, stb, srNJet, presel, dPhiCut=1.0, btagV
     w_err = weight_err_str
   
   #TT Jets yield in srNJet, no b-tag cut, low DPhi
-  fit_srName, fit_srCut = nameAndCut(stb, htb, srNJet, btb=None, presel=presel, btagVar = btagVarString)
+  fit_srName, fit_srCut = nameAndCut(stb, htb, srNJet, btb=None, presel=presel, btagVar = nBTagVar)
 
   if QCD:
     #Get QCD yields in low dPhi for b-tag fit
     QCD_dict={0:{'y':QCD[srNJet][stb][htb][(0,0)]['NQCDpred_lowdPhi'], 'e':QCD[srNJet][stb][htb][(0,0)]['NQCDpred_lowdPhi_err'], 'totalY':QCD[srNJet][stb][htb][(0,0)]['NQCDpred']},\
               1:{'y':QCD[srNJet][stb][htb][(1,1)]['NQCDpred_lowdPhi'], 'e':QCD[srNJet][stb][htb][(1,1)]['NQCDpred_lowdPhi_err'], 'totalY':QCD[srNJet][stb][htb][(1,1)]['NQCDpred']},\
               2:{'y':QCD[srNJet][stb][htb][(2,2)]['NQCDpred_lowdPhi'], 'e':QCD[srNJet][stb][htb][(2,2)]['NQCDpred_lowdPhi_err'], 'totalY':QCD[srNJet][stb][htb][(2,2)]['NQCDpred']}}
-    fit_srNJet_lowDPhi = binnedNBTagsFit(fit_srCut+"&&"+dPhiStr+"<"+str(dPhiCut), fit_srName+'_dPhi'+str(dPhiCut), samples = samples, nBTagVar = btagVarString, lumi=lumi, prefix=fit_srName, printDir=printDir,useBTagWeights=useBTagWeights, btagWeightSuffix=btagWeightSuffix, templateWeights=templateWeights, templateWeightSuffix=templateWeightSuffix, QCD_dict=QCD_dict)
+    fit_srNJet_lowDPhi = binnedNBTagsFit(fit_srCut+"&&"+dPhiStr+"<"+str(dPhiCut), fit_srName+'_dPhi'+str(dPhiCut), samples = samples, prefix=fit_srName, QCD_dict=QCD_dict)
   else:
-    fit_srNJet_lowDPhi = binnedNBTagsFit(fit_srCut+"&&"+dPhiStr+"<"+str(dPhiCut), fit_srName+'_dPhi'+str(dPhiCut), samples = samples, nBTagVar = btagVarString, lumi=lumi, prefix=fit_srName, printDir=printDir,useBTagWeights=useBTagWeights, btagWeightSuffix=btagWeightSuffix, templateWeights=templateWeights, templateWeightSuffix=templateWeightSuffix)
+    fit_srNJet_lowDPhi = binnedNBTagsFit(fit_srCut+"&&"+dPhiStr+"<"+str(dPhiCut), fit_srName+'_dPhi'+str(dPhiCut), samples = samples, prefix=fit_srName)
   
 #  fit_srNJet_lowDPhi = binnedNBTagsFit(fit_srCut+"&&"+dPhiStr+"<"+str(dPhiCut), samples = {'W':cWJets, 'TT':cTTJets}, nBTagVar = 'nBJetMedium25', prefix=fit_srName)
   rd['fit_srNJet_lowDPhi'] = fit_srNJet_lowDPhi
@@ -46,12 +46,12 @@ def makeTTPrediction(bins, samples, htb, stb, srNJet, presel, dPhiCut=1.0, btagV
   yTT_srNJet_0b_lowDPhi =  fit_srNJet_lowDPhi['TT_AllPdg']['yield']*fit_srNJet_lowDPhi['TT_AllPdg']['template'].GetBinContent(1)
   yTT_Var_srNJet_0b_lowDPhi =  fit_srNJet_lowDPhi['TT_AllPdg']['yieldVar']*fit_srNJet_lowDPhi['TT_AllPdg']['template'].GetBinContent(1)**2
 
-  #rCS_crLowNJet_Name_1b, rCS_crLowNJet_Cut_1b = nameAndCut(stb, htb, (4,5), presel=presel, btagVar = btagVarString) 
-  rCS_sr_Name_0b, rCS_sr_Cut_0b = nameAndCut(stb, htb, srNJet, btb=(0,0), presel=presel, btagVar = btagVarString)#for Check 
+  #rCS_crLowNJet_Name_1b, rCS_crLowNJet_Cut_1b = nameAndCut(stb, htb, (4,5), presel=presel, btagVar = nBTagVar) 
+  rCS_sr_Name_0b, rCS_sr_Cut_0b = nameAndCut(stb, htb, srNJet, btb=(0,0), presel=presel, btagVar = nBTagVar)#for Check 
   #rCS_crLowNJet_1b = getRCS(cBkg, rCS_crLowNJet_Cut_1b,  dPhiCut) #Low njet tt-jets CR to be orthoganl to DPhi 
   if useBTagWeights:
-    rCS_crLowNJet_Name, rCS_crLowNJet_Cut = nameAndCut(stb, htb, (4,5), presel=presel, btagVar = btagVarString)
-    rCS_crLowNJet_Name_1b, rCS_crLowNJet_Cut_1b = nameAndCut(stb, htb, (4,5), btb=(1,1), presel=presel, btagVar = btagVarString)
+    rCS_crLowNJet_Name, rCS_crLowNJet_Cut = nameAndCut(stb, htb, (4,5), presel=presel, btagVar = nBTagVar)
+    rCS_crLowNJet_Name_1b, rCS_crLowNJet_Cut_1b = nameAndCut(stb, htb, (4,5), btb=(1,1), presel=presel, btagVar = nBTagVar)
     #getRCS does not work when using btagweights, therefore a more complicated method needs to be used
     #rCS_crLowNJet_1b = getRCS(cData, rCS_crLowNJet_Cut_1b,  dPhiCut, weight = weight_str+'*weightBTag1') #Low njet tt-jets CR to be orthoganl to DPhi
     y_LowDPhi_1b = getYieldFromChain(cRest, cutString = rCS_crLowNJet_Cut_1b+'&&'+dPhiStr+'<'+str(dPhiCut),weight=weight_str)
@@ -73,7 +73,7 @@ def makeTTPrediction(bins, samples, htb, stb, srNJet, presel, dPhiCut=1.0, btagV
     rCS_crLowNJet_1b = {'rCS':y_HighDPhi_1b/y_LowDPhi_1b, 'rCSE_sim':(y_HighDPhi_1b/y_LowDPhi_1b)*sqrt(y_Var_HighDPhi_1b/y_HighDPhi_1b**2+y_Var_LowDPhi_1b/y_LowDPhi_1b**2), 'rCSE_pred':(y_HighDPhi_1b/y_LowDPhi_1b)*sqrt(1./y_HighDPhi_1b+1./y_LowDPhi_1b)}
     rCS_crLowNJet_1b_onlyTT = getRCS(cTTJets, rCS_crLowNJet_Cut,  dPhiCut, weight = weight_str+'*weightBTag1'+btagWeightSuffix) 
   else:
-    rCS_crLowNJet_Name_1b, rCS_crLowNJet_Cut_1b = nameAndCut(stb, htb, (4,5), btb=(1,1), presel=presel, btagVar = btagVarString)
+    rCS_crLowNJet_Name_1b, rCS_crLowNJet_Cut_1b = nameAndCut(stb, htb, (4,5), btb=(1,1), presel=presel, btagVar = nBTagVar)
     if QCD:
       QCD_lowDPhi={'y':QCD[(4,5)][stb][htb][(1,1)]['NQCDpred_lowdPhi'],'e':QCD[(4,5)][stb][htb][(1,1)]['NQCDpred_lowdPhi_err']}
       QCD_highDPhi={'y':QCD[(4,5)][stb][htb][(1,1)]['NQCDpred_highdPhi'],'e':QCD[(4,5)][stb][htb][(1,1)]['NQCDpred_highdPhi_err']}

--- a/RA4Analysis/rCS/makeTable.py
+++ b/RA4Analysis/rCS/makeTable.py
@@ -13,7 +13,7 @@ useTTcorrection = False
 signal = False
 
 prefix = 'singleLeptonic_Spring15_'
-path = '/data/'+username+'/Results2015/Prediction_bweightSFTemplate_Data_fullSR_lep_1.26/'
+path = '/data/'+username+'/Results2015/Prediction_data_newSR_lep_SFtemplates_1.26/'
 #path = '/data/'+username+'/Results2015/Prediction_SFTemplate_MC_fullSR_lep_3.0/' 
 #path2 = '/data/'+username+'/Results2015/Prediction_bweightTemplate_MC_reducedSR_lep_3.0/'
 
@@ -46,7 +46,7 @@ if signal:
     s['chain'] = getChain(s['sample'],histname='')
 
 
-signalRegions = signalRegion3fb
+signalRegions = signalRegion3fbReduced
 #signalRegions = signalRegionCRonly
 
 #signalRegions = smallRegion

--- a/RA4Analysis/rCS/makeWPrediction.py
+++ b/RA4Analysis/rCS/makeWPrediction.py
@@ -221,11 +221,11 @@ def makeWPrediction(bins, samples, htb, stb, srNJet, presel, dPhiCut=1.0, QCD=Fa
   rd['rCS_W_NegPdg_crNJet_0b_truth']  = getRCS(cWJets, 'leptonPdg<0&&'+crCutTruth, dPhiCut)
   
   fit_srName, fit_srCut = nameAndCut(stb, htb, srNJet, btb=None, presel=presel,btagVar = nBTagVar)
-  #QCD yields for b-tag fit
+  #QCD yields in CR for b-tag fit
   if QCD:
-    QCD_dict={0:{'y':QCD[srNJet][stb][htb][(0,0)]['NQCDpred_lowdPhi'], 'e':QCD[srNJet][stb][htb][(0,0)]['NQCDpred_lowdPhi_err'], 'totalY':QCD[srNJet][stb][htb][(0,0)]['NQCDpred']},\
-              1:{'y':QCD[srNJet][stb][htb][(1,1)]['NQCDpred_lowdPhi'], 'e':QCD[srNJet][stb][htb][(1,1)]['NQCDpred_lowdPhi_err'], 'totalY':QCD[srNJet][stb][htb][(1,1)]['NQCDpred']},\
-              2:{'y':QCD[srNJet][stb][htb][(2,2)]['NQCDpred_lowdPhi'], 'e':QCD[srNJet][stb][htb][(2,2)]['NQCDpred_lowdPhi_err'], 'totalY':QCD[srNJet][stb][htb][(2,2)]['NQCDpred']}}
+    QCD_dict={0:{'y':QCD[srNJet][stb][htb][(0,0)][dPhiCut]['NQCDpred_lowdPhi'], 'e':QCD[srNJet][stb][htb][(0,0)][dPhiCut]['NQCDpred_lowdPhi_err'], 'totalY':QCD[srNJet][stb][htb][(0,0)][dPhiCut]['NQCDpred']},\
+              1:{'y':QCD[srNJet][stb][htb][(1,1)][dPhiCut]['NQCDpred_lowdPhi'], 'e':QCD[srNJet][stb][htb][(1,1)][dPhiCut]['NQCDpred_lowdPhi_err'], 'totalY':QCD[srNJet][stb][htb][(1,1)][dPhiCut]['NQCDpred']},\
+              2:{'y':QCD[srNJet][stb][htb][(2,2)][dPhiCut]['NQCDpred_lowdPhi'], 'e':QCD[srNJet][stb][htb][(2,2)][dPhiCut]['NQCDpred_lowdPhi_err'], 'totalY':QCD[srNJet][stb][htb][(2,2)][dPhiCut]['NQCDpred']}}
     fit_srNJet_lowDPhi = binnedNBTagsFit(fit_srCut+"&&"+dPhiStr+"<"+str(dPhiCut), fit_srName+'_dPhi'+str(dPhiCut), samples = samples, prefix=fit_srName, QCD_dict=QCD_dict)
   else:
     fit_srNJet_lowDPhi = binnedNBTagsFit(fit_srCut+"&&"+dPhiStr+"<"+str(dPhiCut), fit_srName+'_dPhi'+str(dPhiCut), samples = samples, prefix=fit_srName)

--- a/RA4Analysis/rCS/makeWPrediction.py
+++ b/RA4Analysis/rCS/makeWPrediction.py
@@ -7,11 +7,11 @@ from rCShelpers import *
 from math import pi, sqrt
 from rCShelpers import *
  
-dPhiStr = 'deltaPhi_Wl'
+from predictionConfig import *
 
 ROOT.TH1F().SetDefaultSumw2()
 
-def makeWPrediction(bins, samples, htb, stb, srNJet, presel, dPhiCut=1.0, btagVarString = 'nBJetMediumCSV30', lumi=4.0, printDir='/afs/hephy.at/user/'+username[0]+'/'+username+'/www/Spring15/defaultDir/templateFit/', useBTagWeights=False, btagWeightSuffix='', templateWeights=False, templateWeightSuffix='', QCD=False, isData=False):
+def makeWPrediction(bins, samples, htb, stb, srNJet, presel, dPhiCut=1.0, QCD=False):
   print "in W predition lumi is :"  , lumi
   if useBTagWeights: 'Will use b-tag weights for W-jets prediction!'
   weight_str, weight_err_str = makeWeight(lumi)
@@ -32,14 +32,14 @@ def makeWPrediction(bins, samples, htb, stb, srNJet, presel, dPhiCut=1.0, btagVa
     w_err = weight_err_str
   
   #TT Jets yield in crNJet, no b-tag cut, low DPhi
-  fit_crName, fit_crCut = nameAndCut(stb, htb, nJetCR, btb=None, presel=presel+'&&abs(leptonPdg)==13', btagVar = btagVarString) 
-  fit_crNJet_lowDPhi = binnedNBTagsFit(fit_crCut+"&&"+dPhiStr+"<"+str(dPhiCut), fit_crName+'_dPhi'+str(dPhiCut)+'_muonChannel', samples=samples, nBTagVar = btagVarString , lumi=lumi, prefix=fit_crName, printDir=printDir, useBTagWeights=useBTagWeights, btagWeightSuffix=btagWeightSuffix, templateWeights=templateWeights, templateWeightSuffix=templateWeightSuffix) #no QCD subtraction - there should only be a very small QCD contamination in muon channel
+  fit_crName, fit_crCut = nameAndCut(stb, htb, nJetCR, btb=None, presel=presel+'&&abs(leptonPdg)==13', btagVar = nBTagVar) 
+  fit_crNJet_lowDPhi = binnedNBTagsFit(fit_crCut+"&&"+dPhiStr+"<"+str(dPhiCut), fit_crName+'_dPhi'+str(dPhiCut)+'_muonChannel', samples=samples, prefix=fit_crName) #no QCD subtraction - there should only be a very small QCD contamination in muon channel
 #  fit_crNJet_lowDPhi = binnedNBTagsFit(fit_crCut+"&&"+dPhiStr+"<"+str(dPhiCut), samples = {'W':cWJets, 'TT':cTTJets}, nBTagVar = 'nBJetMedium25', prefix=fit_crName)
   rd['fit_crNJet_lowDPhi'] = fit_crNJet_lowDPhi
   
-  #rCS_cr_Name_1b, rCS_cr_Cut_1b = nameAndCut(stb, htb, nJetCR, btb=(1,1), presel=presel, btagVar = btagVarString) 
-  rCS_cr_Name_0b, rCS_cr_Cut_0b = nameAndCut(stb, htb, nJetCR, btb=(0,0), presel=presel+'&&abs(leptonPdg)==13', btagVar = btagVarString) #THIS ONE GOT CHANGED FROM 2-3 TO 2-4!
-  #rCS_cr_Name_0b, rCS_cr_Cut_0b = nameAndCut(stb, htb, (2,3), btb=(0,0), presel=presel, btagVar = btagVarString)
+  #rCS_cr_Name_1b, rCS_cr_Cut_1b = nameAndCut(stb, htb, nJetCR, btb=(1,1), presel=presel, btagVar = nBTagVar) 
+  rCS_cr_Name_0b, rCS_cr_Cut_0b = nameAndCut(stb, htb, nJetCR, btb=(0,0), presel=presel+'&&abs(leptonPdg)==13', btagVar = nBTagVar) #THIS ONE GOT CHANGED FROM 2-3 TO 2-4!
+  #rCS_cr_Name_0b, rCS_cr_Cut_0b = nameAndCut(stb, htb, (2,3), btb=(0,0), presel=presel, btagVar = nBTagVar)
   #rCS_crNJet_1b = getRCS(cBkg, rCS_cr_Cut_1b,  dPhiCut) 
   #rCS_crNJet_1b = getRCS(cData, rCS_cr_Cut_1b,  dPhiCut) 
   #rCS_crNJet_1b_onlyTT = getRCS(cTTJets, rCS_cr_Cut_1b,  dPhiCut) 
@@ -50,9 +50,9 @@ def makeWPrediction(bins, samples, htb, stb, srNJet, presel, dPhiCut=1.0, btagVa
   rd['rCS_crNJet_0b_onlyTT'] = rCS_crNJet_0b_onlyTT #no reweighting here, still from MC!
 
   #low njet CR: crNJet, 0-btags, low DPhi
-  crNameTruth, crCutTruth = nameAndCut(stb, htb, nJetCR,btb=(0,0), presel=presel, btagVar=btagVarString) 
-  if useBTagWeights: crName, crCut = nameAndCut(stb, htb, nJetCR, presel=presel, btagVar=btagVarString)
-  else: crName, crCut = nameAndCut(stb, htb, nJetCR,btb=(0,0), presel=presel, btagVar=btagVarString)
+  crNameTruth, crCutTruth = nameAndCut(stb, htb, nJetCR,btb=(0,0), presel=presel, btagVar=nBTagVar) 
+  if useBTagWeights: crName, crCut = nameAndCut(stb, htb, nJetCR, presel=presel, btagVar=nBTagVar)
+  else: crName, crCut = nameAndCut(stb, htb, nJetCR,btb=(0,0), presel=presel, btagVar=nBTagVar)
 
   yTT_crNJet_0b_lowDPhi         = fit_crNJet_lowDPhi['TT_AllPdg']['yield']*fit_crNJet_lowDPhi['TT_AllPdg']['template'].GetBinContent(1)
   yTT_Var_crNJet_0b_lowDPhi     = fit_crNJet_lowDPhi['TT_AllPdg']['yieldVar']*fit_crNJet_lowDPhi['TT_AllPdg']['template'].GetBinContent(1)**2
@@ -220,15 +220,15 @@ def makeWPrediction(bins, samples, htb, stb, srNJet, presel, dPhiCut=1.0, btagVa
   rd['rCS_Var_W_NegPdg_crNJet_0b_notcorr']   = rCS_Var_W_NegPdg_crNJet_0b_notcorr
   rd['rCS_W_NegPdg_crNJet_0b_truth']  = getRCS(cWJets, 'leptonPdg<0&&'+crCutTruth, dPhiCut)
   
-  fit_srName, fit_srCut = nameAndCut(stb, htb, srNJet, btb=None, presel=presel,btagVar = btagVarString)
+  fit_srName, fit_srCut = nameAndCut(stb, htb, srNJet, btb=None, presel=presel,btagVar = nBTagVar)
   #QCD yields for b-tag fit
   if QCD:
     QCD_dict={0:{'y':QCD[srNJet][stb][htb][(0,0)]['NQCDpred_lowdPhi'], 'e':QCD[srNJet][stb][htb][(0,0)]['NQCDpred_lowdPhi_err'], 'totalY':QCD[srNJet][stb][htb][(0,0)]['NQCDpred']},\
               1:{'y':QCD[srNJet][stb][htb][(1,1)]['NQCDpred_lowdPhi'], 'e':QCD[srNJet][stb][htb][(1,1)]['NQCDpred_lowdPhi_err'], 'totalY':QCD[srNJet][stb][htb][(1,1)]['NQCDpred']},\
               2:{'y':QCD[srNJet][stb][htb][(2,2)]['NQCDpred_lowdPhi'], 'e':QCD[srNJet][stb][htb][(2,2)]['NQCDpred_lowdPhi_err'], 'totalY':QCD[srNJet][stb][htb][(2,2)]['NQCDpred']}}
-    fit_srNJet_lowDPhi = binnedNBTagsFit(fit_srCut+"&&"+dPhiStr+"<"+str(dPhiCut), fit_srName+'_dPhi'+str(dPhiCut), samples = samples, nBTagVar = btagVarString, lumi=lumi, prefix=fit_srName, printDir=printDir, useBTagWeights=useBTagWeights, btagWeightSuffix=btagWeightSuffix, templateWeights=templateWeights, templateWeightSuffix=templateWeightSuffix, QCD_dict=QCD_dict)
+    fit_srNJet_lowDPhi = binnedNBTagsFit(fit_srCut+"&&"+dPhiStr+"<"+str(dPhiCut), fit_srName+'_dPhi'+str(dPhiCut), samples = samples, prefix=fit_srName, QCD_dict=QCD_dict)
   else:
-    fit_srNJet_lowDPhi = binnedNBTagsFit(fit_srCut+"&&"+dPhiStr+"<"+str(dPhiCut), fit_srName+'_dPhi'+str(dPhiCut), samples = samples, nBTagVar = btagVarString, lumi=lumi, prefix=fit_srName, printDir=printDir, useBTagWeights=useBTagWeights, btagWeightSuffix=btagWeightSuffix, templateWeights=templateWeights, templateWeightSuffix=templateWeightSuffix)
+    fit_srNJet_lowDPhi = binnedNBTagsFit(fit_srCut+"&&"+dPhiStr+"<"+str(dPhiCut), fit_srName+'_dPhi'+str(dPhiCut), samples = samples, prefix=fit_srName)
 #  fit_srNJet_lowDPhi = binnedNBTagsFit(fit_srCut+"&&"+dPhiStr+"<"+str(dPhiCut), samples = {'W':cWJets, 'TT':cTTJets}, nBTagVar = 'nBJetMedium25', prefix=fit_srName)
 
   rd['fit_srNJet_lowDPhi_W'] = fit_srNJet_lowDPhi
@@ -259,7 +259,7 @@ def makeWPrediction(bins, samples, htb, stb, srNJet, presel, dPhiCut=1.0, btagVa
   rd['rCS_crLowNJet_0b_onlyW_mu_PosPdg'] = rCS_crLowNJet_0b_onlyW_mu_PosPdg
   rd['rCS_crLowNJet_0b_onlyW_mu_NegPdg'] = rCS_crLowNJet_0b_onlyW_mu_NegPdg
   
-  rCS_sr_Name_0b, rCS_sr_Cut_0b = nameAndCut(stb, htb, srNJet, btb=(0,0), presel=presel, btagVar = btagVarString)#for Check 
+  rCS_sr_Name_0b, rCS_sr_Cut_0b = nameAndCut(stb, htb, srNJet, btb=(0,0), presel=presel, btagVar = nBTagVar)#for Check 
   rCS_srNJet_0b_onlyW = getRCS(cWJets, rCS_sr_Cut_0b,  dPhiCut) #for check
   rCS_srNJet_0b_onlyW_mu = getRCS(cWJets, rCS_sr_Cut_0b+'&&abs(leptonPdg)==13',  dPhiCut) #for check
   rCS_srNJet_0b_onlyW_ele = getRCS(cWJets, rCS_sr_Cut_0b+'&&abs(leptonPdg)==11',  dPhiCut) #for check

--- a/RA4Analysis/rCS/predictionConfig.py
+++ b/RA4Analysis/rCS/predictionConfig.py
@@ -11,7 +11,7 @@ from Workspace.RA4Analysis.cmgTuples_Spring15_25ns_HT500ST250_postProcessed_from
 from Workspace.HEPHYPythonTools.user import username
 from Workspace.RA4Analysis.signalRegions import *
 
-testRun = True
+testRun = False
 
 ## b-tagging and other variables
 dPhiStr = 'deltaPhi_Wl'
@@ -24,7 +24,7 @@ templateWeightSuffix = '_SF'
 
 
 ## samples
-isData = False
+isData = True
 
 cWJets      = getChain(WJetsHT_25ns_btagweight,histname='')
 cTTJets     = getChain(TTJets_HTLO_25ns_btagweight,histname='')
@@ -41,7 +41,7 @@ else:
 
 
 ## signal region definition
-signalRegions = signalRegion3fb
+signalRegions = signalRegion3fbReduced
 
 
 ## weight calculations
@@ -51,9 +51,9 @@ sampleLumi = 3.
 debugReweighting = False
 
 ## QCD estimation
-QCDpickle = '/data/dhandl/results2015/QCDEstimation/20151106_QCDestimation_pkl'
+QCDpickle = '/data/dhandl/results2015/QCDEstimation/20151111_QCDestimation_pkl'
 QCDestimate = pickle.load(file(QCDpickle))
-QCDestimate=False
+#QCDestimate=False
 
 
 ## Directories for plots, results and templates
@@ -71,6 +71,8 @@ filters = "Flag_goodVertices && Flag_HBHENoiseFilter_fix && Flag_CSCTightHaloFil
 presel = "((!isData&&singleLeptonic)||(isData&&"+triggers+"&&((muonDataSet&&singleMuonic)||(eleDataSet&&singleElectronic))&&"+filters+"))"
 presel += "&& nLooseHardLeptons==1 && nTightHardLeptons==1 && nLooseSoftLeptons==0 && Jet_pt[1]>80 && st>250 && nJet30>2 && htJet30j>500"
 
+singleMu_presel = "((!isData&&singleMuonic)||(isData&&"+triggers+"&&(muonDataSet&&singleMuonic)&&"+filters+"))"
+singleMu_presel += "&& nLooseHardLeptons==1 && nTightHardLeptons==1 && nLooseSoftLeptons==0 && Jet_pt[1]>80 && st>250 && nJet30>2 && htJet30j>500"
 
 ## corrections
 createFits = True

--- a/RA4Analysis/rCS/predictionConfig.py
+++ b/RA4Analysis/rCS/predictionConfig.py
@@ -51,7 +51,7 @@ sampleLumi = 3.
 debugReweighting = False
 
 ## QCD estimation
-QCDpickle = '/data/dhandl/results2015/QCDEstimation/20151111_QCDestimation_pkl'
+QCDpickle = '/data/dhandl/results2015/QCDEstimation/20151111_QCDestimation_fix_pkl'
 QCDestimate = pickle.load(file(QCDpickle))
 #QCDestimate=False
 

--- a/RA4Analysis/rCS/predictionConfig.py
+++ b/RA4Analysis/rCS/predictionConfig.py
@@ -1,0 +1,97 @@
+## use this file to define all necessary samples, variables etc needed for the entire prediction process
+
+import ROOT
+import pickle
+import os,sys
+from Workspace.HEPHYPythonTools.helpers import getChain
+
+from Workspace.RA4Analysis.cmgTuples_Spring15_25ns_HT500ST250_postProcessed_btagWeight import *
+from Workspace.RA4Analysis.cmgTuples_Spring15_25ns_HT500ST250_postProcessed_fromArthur import *
+
+from Workspace.HEPHYPythonTools.user import username
+from Workspace.RA4Analysis.signalRegions import *
+
+testRun = True
+
+## b-tagging and other variables
+dPhiStr = 'deltaPhi_Wl'
+bjreg = (0,0)
+nBTagVar = 'nBJetMediumCSV30'
+useBTagWeights = False #True for weighted fake data, false for data
+btagWeightSuffix = ''
+templateWeights = True
+templateWeightSuffix = '_SF'
+
+
+## samples
+isData = False
+
+cWJets      = getChain(WJetsHT_25ns_btagweight,histname='')
+cTTJets     = getChain(TTJets_HTLO_25ns_btagweight,histname='')
+cDY         = getChain(DY_25ns,histname='')
+csingleTop  = getChain(singleTop_25ns,histname='')
+cTTV        = getChain(TTV_25ns,histname='')
+cRest       = getChain([singleTop_25ns, DY_25ns, TTV_25ns],histname='')#no QCD
+cBkg        = getChain([WJetsHT_25ns_btagweight, TTJets_HTLO_25ns_btagweight, singleTop_25ns, DY_25ns, TTV_25ns], histname='')#no QCD
+
+if isData:
+  cData = getChain([SingleMuon_Run2015D, SingleElectron_Run2015D], histname='')
+else:
+  cData = getChain([WJetsHT_25ns_btagweight, TTJets_HTLO_25ns_btagweight, singleTop_25ns, DY_25ns, TTV_25ns], histname='')
+
+
+## signal region definition
+signalRegions = signalRegion3fb
+
+
+## weight calculations
+lumi = 1.26
+templateLumi = 1.26 # lumi that was used when template was created - if defined wrong, fixed rest backgrounds will be wrong
+sampleLumi = 3.
+debugReweighting = False
+
+## QCD estimation
+QCDpickle = '/data/dhandl/results2015/QCDEstimation/20151106_QCDestimation_pkl'
+QCDestimate = pickle.load(file(QCDpickle))
+QCDestimate=False
+
+
+## Directories for plots, results and templates
+predictionName = 'data_newSR_lep_SFtemplates'
+templateName   = 'SFtemplates_for_data_newSR_lep'
+printDir    = '/afs/hephy.at/user/'+username[0]+'/'+username+'/www/Spring15/25ns/templateFit_'+predictionName+'_'+str(lumi)+'/'
+pickleDir   = '/data/'+username+'/Results2015/Prediction_'+predictionName+'_'+str(lumi)+'/'
+templateDir = '/data/'+username+'/Results2015/btagTemplates_'+templateName+'_'+str(templateLumi)+'/'
+prefix = 'singleLeptonic_Spring15_'
+
+
+## Preselection cut
+triggers = "(HLT_EleHT350||HLT_MuHT350)"
+filters = "Flag_goodVertices && Flag_HBHENoiseFilter_fix && Flag_CSCTightHaloFilter && Flag_eeBadScFilter && Flag_HBHENoiseIsoFilter"
+presel = "((!isData&&singleLeptonic)||(isData&&"+triggers+"&&((muonDataSet&&singleMuonic)||(eleDataSet&&singleElectronic))&&"+filters+"))"
+presel += "&& nLooseHardLeptons==1 && nTightHardLeptons==1 && nLooseSoftLeptons==0 && Jet_pt[1]>80 && st>250 && nJet30>2 && htJet30j>500"
+
+
+## corrections
+createFits = True
+fitDir = '/data/'+username+'/Results2015/correctionFit_btagKappa_data_fullSR/'
+
+
+## do stuff for test runs
+if testRun:
+  signalRegions = smallRegion
+  predictionName = 'testRun'
+  printDir    = '/afs/hephy.at/user/'+username[0]+'/'+username+'/www/Spring15/25ns/templateFit_'+predictionName+'_'+str(lumi)+'/'
+  pickleDir   = '/data/'+username+'/Results2015/Prediction_'+predictionName+'_'+str(lumi)+'/'
+  templateDir = '/data/'+username+'/Results2015/btagTemplates_'+predictionName+'_'+str(templateLumi)+'/'
+
+
+## create directories that are defined but do not yet exist
+if not os.path.exists(fitDir):
+  os.makedirs(fitDir)
+if not os.path.exists(pickleDir):
+  os.makedirs(pickleDir)
+if not os.path.exists(printDir):
+  os.makedirs(printDir)
+if not os.path.exists(templateDir):
+  os.makedirs(templateDir)


### PR DESCRIPTION
Using a dedicated config file meant to be used in all steps of prediction - so cuts, variables etc are always the same
Parameters for functions are reduced because of the config file
QCD is added to the b-tag fit if the data has to be corrected. It's treated the same way as the rest bkg, so the yield is kept fixed.
Fix in b-tag fit (nbjet=2 -> nbjet>=2 also when using b-tag weights for template creation)
QCD estimation dictionary has an additional key for deltaPhiCut value - otherwise different deltaPhi cut values will be overwritten in the side-bands (3,4 and 4,5 jet regions)
