### PR TITLE
getSamples changes

### DIFF
--- a/DegenerateStopAnalysis/python/cmgTuples_Spring15_7412pass2.py
+++ b/DegenerateStopAnalysis/python/cmgTuples_Spring15_7412pass2.py
@@ -165,7 +165,16 @@ WJetsToLNu_HT2500toInf ={\
 
 TTJets = [TTJets_LO, TTJets_LO_HT600to800, TTJets_LO_HT800to1200, TTJets_LO_HT1200to2500, TTJets_LO_HT2500toInf]
 WJetsInc = [WJetsToLNu]
-WJetsHT  = [WJetsToLNu_HT100to200, WJetsToLNu_HT200to400, WJetsToLNu_HT400to600, WJetsToLNu_HT600toInf, WJetsToLNu_HT600to800, WJetsToLNu_HT800to1200, WJetsToLNu_HT1200to2500 , WJetsToLNu_HT2500toInf]
+WJetsHT  = [
+    WJetsToLNu_HT100to200, 
+    WJetsToLNu_HT200to400, 
+    WJetsToLNu_HT400to600, 
+    WJetsToLNu_HT600toInf, 
+    WJetsToLNu_HT600to800, 
+    WJetsToLNu_HT800to1200, 
+    WJetsToLNu_HT1200to2500 , 
+    WJetsToLNu_HT2500toInf,
+    ]
 
 samples = TTJets + WJetsInc + WJetsHT
 


### PR DESCRIPTION
Search for sample definition module if the cmgTuple is not among the hard-wired values.

Expected file to be found in python directory:
moduleName = 'cmgTuples_'  + cmgTuples

For example, for 
cmgTuples_Spring15_withTracks.py, 
the cmgTuple argument to be given is 
--cmgTuples=' Spring15_withTracks'.

The output directory is now organized as
    outDir = os.path.join(targetDir, processingEra, processingTag, cmgTuples)

e.g.
/afs/hephy.at/user/v/vghete/vghete01/cmgTuples/postProcessed_mAODv2/v0/RunIISpring15DR74_25ns/{lepton selection}/{sample}

See file for default values.
